### PR TITLE
Expose the ConvertErrors func

### DIFF
--- a/openapi3filter/validation_error_encoder.go
+++ b/openapi3filter/validation_error_encoder.go
@@ -17,16 +17,18 @@ type ValidationErrorEncoder struct {
 
 // Encode implements the ErrorEncoder interface for encoding ValidationErrors
 func (enc *ValidationErrorEncoder) Encode(ctx context.Context, err error, w http.ResponseWriter) {
+	enc.Encoder(ctx, ConvertErrors(err), w)
+}
+
+// ConvertErrors converts all errors to the appropriate error format.
+func ConvertErrors(err error) error {
 	if e, ok := err.(*routers.RouteError); ok {
-		cErr := convertRouteError(e)
-		enc.Encoder(ctx, cErr, w)
-		return
+		return convertRouteError(e)
 	}
 
 	e, ok := err.(*RequestError)
 	if !ok {
-		enc.Encoder(ctx, err, w)
-		return
+		return err
 	}
 
 	var cErr *ValidationError
@@ -43,10 +45,9 @@ func (enc *ValidationErrorEncoder) Encode(ctx context.Context, err error, w http
 	}
 
 	if cErr != nil {
-		enc.Encoder(ctx, cErr, w)
-		return
+		return cErr
 	}
-	enc.Encoder(ctx, err, w)
+	return err
 }
 
 func convertRouteError(e *routers.RouteError) *ValidationError {


### PR DESCRIPTION
- Expose a function that can convert errors to the appropriate error format.

Note:
will have a separate pr for [this one](https://github.com/getkin/kin-openapi/compare/master...confluentinc:kin-openapi:ignore-servers#diff-1a9a87f866902eedcb4bff892680de5f9f66a61e155e976660f563e4e2431504R119) and test if this change is still needed. But not a blocker for current pr.